### PR TITLE
Extend integer types

### DIFF
--- a/builtins.c
+++ b/builtins.c
@@ -14,6 +14,10 @@ int print(uint64_t inp) {
     return printf("%" PRId64, inp);
 }
 
+int println_32(int32_t inp) {
+    return printf("%d\n", inp);
+}
+
 // Print a string to stdout with a newline
 int println(uint64_t inp) {
     return printf("%" PRId64 "\n", inp);
@@ -49,7 +53,15 @@ uint32_t ilt (uint32_t a, uint16_t b) {
     return a < b;
 }
 
+uint32_t ilteq (uint32_t a, uint16_t b) {
+    return a <= b;
+}
+
 // Check if the first integer is greater than the second, return 1 if true, 0 if false
 uint32_t igt (uint32_t a, uint16_t b) {
     return a > b;
+}
+
+void terminate(int code) {
+    exit(code);
 }

--- a/examples/builtins.wellick
+++ b/examples/builtins.wellick
@@ -1,3 +1,3 @@
-fn main() -> int {
+fn main() -> i32 {
     return iadd(10, 10);
 }

--- a/examples/default_const.wellick
+++ b/examples/default_const.wellick
@@ -1,5 +1,5 @@
-fn main() -> int {
-    let y = 10;
+fn main() -> i32 {
+    let y: i32 = 10;
     y = 15;
     return 0;
 }

--- a/examples/fibonacci.wellick
+++ b/examples/fibonacci.wellick
@@ -1,12 +1,13 @@
-fn fibonacci(n: int) -> int {
-    if ieq(n, 1) {
-        return 1;
+fn fibonacci(n: i32) -> i32 {
+    if ilteq(n, 1) {
+        return n;
     }
-    x: int = fibonacci(isub(n, 1));
-    y: int = fibonacci(isub(n, 2));
+    let x: i32 = fibonacci(isub(n, 1));
+    let y: i32 = fibonacci(isub(n, 2));
     return iadd(x, y);
 }
 
-fn main() -> int {
-    return fibonacci(10);
+fn main() -> i32 {
+    println(fibonacci(40));
+    return 0;
 }

--- a/examples/ptr_type.wellick
+++ b/examples/ptr_type.wellick
@@ -1,8 +1,8 @@
-fn main() -> int {
-    let x: isize = 10;
-    let y: isize = &x;
+fn main() -> i32 {
+    let x: i64 = 10;
+    let y: *i64 = &x;
     println(y);
-    let z: isize = *y;
+    let z: i64 = *y;
     println(z);
     return 0;
 }

--- a/run.py
+++ b/run.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     outfile = pathlib.Path("a.out")
-    env = {**os.environ, "RUST_BACKTRACE": "1"}
+    env = {**os.environ, "RUST_BACKTRACE": "full"}
 
     if outfile.is_file():
         outfile.unlink()
@@ -41,6 +41,8 @@ if __name__ == "__main__":
     if platform.system() == "Windows":
         if compile_stdlib:
             cprint("Compiling stdlib", GREEN)
+            os.unlink("builtins.obj")
+            os.unlink("builtins.dll")
             subprocess.check_call(["cl", "builtins.c", "/LD", "/MD", "/Wall"])
         subprocess.check_call(["LINK", outfile, "builtins", "/SUBSYSTEM:CONSOLE"])
         result = subprocess.run(["a.exe"])

--- a/wellick/Cargo.toml
+++ b/wellick/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.1.8", features = ["derive"] }
-cranelift = "0.92.0"
-cranelift-codegen = { version = "0.92.0", features = ["arm64", "x86"] }
-cranelift-frontend = "0.92.0"
-cranelift-module = "0.92.0"
-cranelift-native = "0.92.0"
-cranelift-object = "0.92.0"
+cranelift = "0.94.0"
+cranelift-codegen = { version = "0.94.0", features = ["arm64", "x86"] }
+cranelift-frontend = "0.94.0"
+cranelift-module = "0.94.0"
+cranelift-native = "0.94.0"
+cranelift-object = "0.94.0"
 lazy_static = "1.4.0"
 nom = "7.1.3"

--- a/wellick/src/compiler/mod.rs
+++ b/wellick/src/compiler/mod.rs
@@ -96,32 +96,6 @@ impl Compiler {
         Ok(())
     }
 
-    fn decl_stdlib(&mut self) {
-        let mut sig_a = self.module.make_signature();
-        sig_a.params.push(AbiParam::new(types::I32));
-        sig_a.params.push(AbiParam::new(types::I32));
-        sig_a.returns.push(AbiParam::new(types::I32));
-        self.module
-            .declare_function("iadd", Linkage::Local, &sig_a)
-            .unwrap();
-
-        let mut sig_b = self.module.make_signature();
-        sig_b.params.push(AbiParam::new(types::I32));
-        sig_b.params.push(AbiParam::new(types::I32));
-        sig_b.returns.push(AbiParam::new(types::I32));
-        self.module
-            .declare_function("ieq", Linkage::Local, &sig_b)
-            .unwrap();
-
-        let mut sig_c = self.module.make_signature();
-        sig_c.params.push(AbiParam::new(types::I32));
-        sig_c.params.push(AbiParam::new(types::I32));
-        sig_c.returns.push(AbiParam::new(types::I32));
-        self.module
-            .declare_function("isub", Linkage::Import, &sig_c)
-            .unwrap();
-    }
-
     fn translate(&mut self, code: Vec<ast::FnDecl>) {
         for func in code {
             self.translate_decl(func);

--- a/wellick/src/compiler/mod.rs
+++ b/wellick/src/compiler/mod.rs
@@ -6,7 +6,6 @@ use crate::parser::ast;
 use cranelift::codegen;
 use cranelift::prelude::AbiParam;
 use cranelift::prelude::Configurable;
-use cranelift_codegen::ir::types;
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use cranelift_module::{DataContext, Linkage, Module};
 use cranelift_native::builder as host_isa_builder;

--- a/wellick/src/compiler/translate.rs
+++ b/wellick/src/compiler/translate.rs
@@ -42,8 +42,7 @@ impl<'a, 'b> FunctionTranslator<'a, 'b> {
     ) -> Value {
         let then_block = self.builder.create_block();
         let merge_block = self.builder.create_block();
-        let cond_expr = self.translate_expr(condition);
-        let cond = self.builder.ins().icmp_imm(IntCC::Equal, cond_expr, 1);
+        let cond = self.translate_expr(condition);
         self.builder
             .ins()
             .brif(cond, then_block, &[], merge_block, &[]);

--- a/wellick/src/parser/ast.rs
+++ b/wellick/src/parser/ast.rs
@@ -4,32 +4,40 @@ use std::option::Option;
 /// value, used in AST constructs like assignments
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub enum Value {
-    Float(f32),
-    Integer(isize),
+    F32(f32),
+    I32(i32),
+}
+
+#[derive(Debug, Clone)]
+pub enum IntegerType {
+    I32,
+    I64,
+    PointerSize,
+}
+
+#[derive(Debug, Clone)]
+pub enum FloatType {
+    F32,
+    F64,
 }
 
 #[derive(Debug, Clone)]
 pub enum EmptyType {
-    Float,
-    Integer,
-    Pointer,
+    Float(FloatType),
+    Integer(IntegerType),
+    Pointer(Box<EmptyType>),
 }
 
 #[derive(Debug, Clone)]
 pub struct Assignment {
     pub target: Name,
     pub value: Expression,
-    pub var_type: Option<EmptyType>,
+    pub var_type: EmptyType,
     pub mutable: bool,
 }
 
 impl Assignment {
-    pub fn new(
-        target: Name,
-        var_type: Option<EmptyType>,
-        value: Expression,
-        mutable: bool,
-    ) -> Self {
+    pub fn new(target: Name, var_type: EmptyType, value: Expression, mutable: bool) -> Self {
         Self {
             target,
             var_type,

--- a/wellick/src/parser/literals.rs
+++ b/wellick/src/parser/literals.rs
@@ -17,7 +17,7 @@ fn hexadecimal(input: &str) -> IResult<&str, Value> {
                 many0(char('_')),
             ))),
         ),
-        |value: &str| Value::Integer(value.parse::<isize>().unwrap()),
+        |value: &str| Value::I32(value.parse::<i32>().unwrap()),
     )(input)
 }
 
@@ -27,14 +27,14 @@ fn octal(input: &str) -> IResult<&str, Value> {
             tag_no_case("0o"),
             recognize(many1(terminated(one_of("01234567"), many0(char('_'))))),
         ),
-        |value: &str| Value::Integer(value.parse::<isize>().unwrap()),
+        |value: &str| Value::I32(value.parse::<i32>().unwrap()),
     )(input)
 }
 
 fn decimal(input: &str) -> IResult<&str, Value> {
     map(
         recognize(many1(terminated(one_of("0123456789"), many0(char('_'))))),
-        |value: &str| Value::Integer(value.parse::<isize>().unwrap()),
+        |value: &str| Value::I32(value.parse::<i32>().unwrap()),
     )(input)
 }
 
@@ -56,7 +56,7 @@ fn float(input: &str) -> IResult<&str, Value> {
             ))), // Case three: 42. and 42.42
             recognize(tuple((decimal, char('.'), opt(decimal)))),
         )),
-        |value: &str| Value::Float(value.parse::<f32>().unwrap()),
+        |value: &str| Value::F32(value.parse::<f32>().unwrap()),
     )(input)
 }
 

--- a/wellick/src/parser/stmts.rs
+++ b/wellick/src/parser/stmts.rs
@@ -71,7 +71,7 @@ pub fn assignment(input: &str) -> IResult<&str, Assignment> {
             tuple((
                 ws(mutable_qualifier),
                 identifier_to_obj,
-                opt(preceded(ws(tag(":")), arg_type)),
+                preceded(ws(tag(":")), arg_type),
                 ws(char('=')),
                 expression,
             )),


### PR DESCRIPTION
Extend integer types from basic `int`, `float`, etc.

Adds:

* i32
* i64
* isize
* f32
* f64